### PR TITLE
Adding a Deploy to Heroku Button

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: gunicorn --pythonpath 'src/' -w 4 "FlaskRTBCTF:create_app()"

--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ $ cd src/
    ```
 4. Your app should be live now. You can run `heroku open` to open it in browser.
 
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
+
 ## For Your CTF
 
 Using this as simple as anything. 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ $ cd src/
 
 ### Deployment using Heroku
 
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
+
+or do it manually,
+
 1. Create your heroku app using `heroku` cli tool.
    
    Follow the official guide by Heroku: https://devcenter.heroku.com/articles/getting-started-with-python#prepare-the-app
@@ -78,7 +82,6 @@ $ cd src/
    ```
 4. Your app should be live now. You can run `heroku open` to open it in browser.
 
-[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
 
 ## For Your CTF
 

--- a/app.json
+++ b/app.json
@@ -1,0 +1,18 @@
+{
+  "name": "RootTheBox CTF Framework",
+  "description": "A lightweight, easy to deploy CTF framework(in Flask) for HackTheBox style machines.",
+  "repository": "https://github.com/svensevenslow/RTB-CTF-Framework",
+  "addons": [
+    {
+      "plan": "heroku-postgresql"
+    }
+  ],
+  "buildpacks": [
+    {
+      "url": "heroku/python"
+    }
+  ],
+  "scripts": {
+    "postdeploy": "python3 src/create_db.py"
+  }
+}

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "name": "RootTheBox CTF Framework",
   "description": "A lightweight, easy to deploy CTF framework(in Flask) for HackTheBox style machines.",
-  "repository": "https://github.com/svensevenslow/RTB-CTF-Framework",
+  "repository": "https://github.com/abs0lut3pwn4g3/RTB-CTF-Framework",
   "addons": [
     {
       "plan": "heroku-postgresql"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+src/requirements.txt

--- a/src/Procfile
+++ b/src/Procfile
@@ -1,1 +1,0 @@
-web: gunicorn -w 4 "FlaskRTBCTF:create_app()"


### PR DESCRIPTION
Hi! You can test the button functionality [here](https://github.com/svensevenslow/RTB-CTF-Framework/tree/herokuButton-gssoc20-dev#deployment-using-heroku)
Right now I have added the url of my forked [repo](https://github.com/svensevenslow/RTB-CTF-Framework.git) so that you can check out the functionality, if you'll be ok with the changes I'll change the url to [this](https://github.com/abs0lut3pwn4g3/RTB-CTF-Framework.git)
The app that I deployed using this button can be seen [here](https://ctf-button.herokuapp.com/)