### PR TITLE
Preventing score updation after contest has ended

### DIFF
--- a/src/FlaskRTBCTF/templates/machine.html
+++ b/src/FlaskRTBCTF/templates/machine.html
@@ -45,6 +45,9 @@
 
     <hr/>
 
+    {% if end < current %}
+    The CTF has ended. Please see <a class="red-underlined-link" href="{{ url_for('ctf.scoreboard') }}">scoreboard</a>
+    {% else %}
     <!-- User Hash Form -->
     <form class="form-inline" method="POST" action="{{ url_for('ctf.validateUserHash') }}">
         {{ userHashForm.hidden_tag() }}
@@ -90,7 +93,7 @@
             {{ rootHashForm.submit(class="btn btn-dark btn-hover-red") }}
         </div>
     </form>
-
+    {% endif %}
     
 </div>
 


### PR DESCRIPTION
The logic I've used here is that the user/root hash submission cannot be done once the contest has ended, so the score will not get updated and thus scoreboard will not get updated. 